### PR TITLE
build: wire tests, coverage, static analysis, and Tracy options in CMake

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,98 @@
+name: code-coverage
+
+on:
+  push:
+    branches: [ master, Matrix, Nexus ]
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - '**.c'
+      - 'CMakeLists.txt'
+      - 'tests/**'
+      - 'src/**'
+      - 'lib/**'
+  pull_request:
+    branches: [ master, Matrix, Nexus ]
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - '**.c'
+      - 'CMakeLists.txt'
+      - 'tests/**'
+      - 'src/**'
+      - 'lib/**'
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    name: gcov / lcov
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake \
+            g++ \
+            ninja-build \
+            lcov \
+            libgl1-mesa-dev \
+            libglu1-mesa-dev
+
+      - name: Configure CMake with coverage and tests
+        run: |
+          mkdir -p build
+          cd build
+          cmake -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DBUILD_TESTING=ON \
+            -DENABLE_COVERAGE=ON \
+            ..
+
+      - name: Build
+        run: cmake --build build --parallel "$(nproc)"
+
+      - name: Run tests
+        run: |
+          cd build
+          ctest --output-on-failure
+
+      - name: Capture coverage (lcov)
+        run: |
+          lcov --directory build --capture \
+               --output-file build/coverage.info \
+               --ignore-errors mismatch
+          # Limit the report to the project's own sources (exclude system,
+          # third-party, and test-framework code).
+          lcov --remove build/coverage.info \
+               '/usr/*' \
+               '*/lib/kissfft/*' \
+               '*/_deps/*' \
+               '*/tests/*' \
+               --output-file build/coverage.filtered.info \
+               --ignore-errors unused
+
+      - name: Generate HTML report
+        run: |
+          genhtml build/coverage.filtered.info \
+            --output-directory build/coverage-html
+
+      - name: Summarize coverage
+        run: |
+          lcov --summary build/coverage.filtered.info || true
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: |
+            build/coverage.info
+            build/coverage.filtered.info
+            build/coverage-html/
+          retention-days: 30

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ option(BUILD_TESTING "Build tests" OFF)
 option(ENABLE_COVERAGE "Enable code coverage" OFF)
 option(ENABLE_CLANG_TIDY "Enable clang-tidy" OFF)
 option(ENABLE_CPPCHECK "Enable cppcheck" OFF)
+option(ENABLE_TRACY "Enable Tracy profiler instrumentation (requires tracy headers when enabled)" OFF)
+option(TRACY_ON_DEMAND "Only collect Tracy zones when a profiler is attached" ON)
 
 # Fetch kissfft dependency
 include(FetchContent)
@@ -73,6 +75,7 @@ set(MATRIX_SOURCES
 
 set(MATRIX_HEADERS
   src/main.h
+  src/tracyprofiler.h
   src/stb_image.h
   ${kissfft_SOURCE_DIR}/kiss_fft.h
   ${kissfft_SOURCE_DIR}/kiss_fft_log.h
@@ -120,21 +123,74 @@ set(CPACK_PACKAGE_VENDOR ${PROJECT_AUTHOR})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${PROJECT_DESCRIPTION})
 set(CPACK_RESOURCE_FILE_LICENSE ${PROJECT_SOURCE_DIR}/LICENSE.md)
 
-# Enable testing if requested
+# Code coverage (gcov/lcov)
+#
+# Build with: cmake -DBUILD_TESTING=ON -DENABLE_COVERAGE=ON ..
+# Run tests, then: lcov --capture --directory . --output-file coverage.info
+#                  genhtml coverage.info --output-directory coverage-html
+#
+# Configured before the test subdirectory so the test target inherits the
+# coverage compile/link flags too.
+if(ENABLE_COVERAGE)
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    message(FATAL_ERROR "ENABLE_COVERAGE requires GCC or Clang")
+  endif()
+  add_compile_options(--coverage -O0 -g)
+  add_link_options(--coverage)
+endif()
+
+# Static analysis integration
+#
+# Clang-Tidy: enabled with -DENABLE_CLANG_TIDY=ON (Clang toolchain recommended).
+#   Runs as part of the build; failures (treated as errors) break the build.
+# Cppcheck:   enabled with -DENABLE_CPPCHECK=ON. Runs as a build hook on the
+#   main target's sources; non-zero exit fails the build.
+if(ENABLE_CLANG_TIDY)
+  find_program(CLANG_TIDY_BIN NAMES clang-tidy clang-tidy-14 clang-tidy-15 clang-tidy-16)
+  if(CLANG_TIDY_BIN)
+    set(CMAKE_CXX_CLANG_TIDY
+      "${CLANG_TIDY_BIN};-checks=*,-modernize-use-trailing-return-type;-warnings-as-errors=*;-quiet")
+    message(STATUS "clang-tidy enabled: ${CLANG_TIDY_BIN}")
+  else()
+    message(WARNING "ENABLE_CLANG_TIDY=ON but clang-tidy not found; skipping.")
+  endif()
+endif()
+
+if(ENABLE_CPPCHECK)
+  find_program(CPPCHECK_BIN NAMES cppcheck)
+  if(CPPCHECK_BIN)
+    set(CMAKE_CXX_CPPCHECK
+      "${CPPCHECK_BIN};--enable=warning,style;--inconclusive;--std=c++17;--suppress=missingIncludeSystem;--error-exitcode=1")
+    message(STATUS "cppcheck enabled: ${CPPCHECK_BIN}")
+  else()
+    message(WARNING "ENABLE_CPPCHECK=ON but cppcheck not found; skipping.")
+  endif()
+endif()
+
+# Tracy profiler integration (optional).
+#
+# When ENABLE_TRACY is ON and the tracy headers are available (TracyClient.cpp
+# is expected to be compiled by the consuming project or via FetchContent), the
+# addon is instrumented with zone scopes. When the headers are absent, the
+# include is skipped and profiling is a no-op, so enabling the option is safe
+# even without tracy installed.
+if(ENABLE_TRACY)
+  find_path(TRACY_INCLUDE_DIR NAMES tracy/Tracy.hpp)
+  if(TRACY_INCLUDE_DIR)
+    target_compile_definitions(visualization.matrix PRIVATE TRACY_ENABLE)
+    if(TRACY_ON_DEMAND)
+      target_compile_definitions(visualization.matrix PRIVATE TRACY_ON_DEMAND)
+    endif()
+    target_include_directories(visualization.matrix PRIVATE ${TRACY_INCLUDE_DIR})
+    message(STATUS "Tracy profiler enabled (include: ${TRACY_INCLUDE_DIR})")
+  else()
+    message(STATUS "ENABLE_TRACY=ON but tracy headers not found; instrumentation disabled.")
+  endif()
+endif()
+
+# Enable testing if requested. Done after coverage/analysis setup so the test
+# target inherits the same compile/link flags (e.g. --coverage).
 if(BUILD_TESTING)
   enable_testing()
-  # Add tests here when available
-endif()
-
-# Code coverage
-if(ENABLE_COVERAGE)
-  target_compile_options(visualization.matrix PRIVATE --coverage)
-  target_link_options(visualization.matrix PRIVATE --coverage)
-endif()
-
-# Clang-tidy integration
-if(ENABLE_CLANG_TIDY AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set_target_properties(visualization.matrix PROPERTIES
-    CXX_CLANG_TIDY "clang-tidy;-checks=*;-warnings-as-errors=*"
-  )
+  add_subdirectory(tests)
 endif()

--- a/src/tracyprofiler.h
+++ b/src/tracyprofiler.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2005-2021 Team Kodi <https://kodi.tv>
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+#pragma once
+
+// Dependency-free Tracy profiler instrumentation shim.
+//
+// When TRACY_ENABLE is defined AND the tracy headers are available on the
+// include path (e.g. via -DENABLE_TRACY=ON, which adds tracy/ to the include
+// path), the Tracy macros are pulled in and zones are recorded. Otherwise the
+// macros expand to nothing, so the source can be instrumented unconditionally
+// without forcing a tracy dependency on regular builds.
+//
+// Usage:
+//   #include "tracyprofiler.h"
+//   void Render() {
+//     TRACY_ZONE("Render");
+//     ...
+//   }
+//
+// Notes:
+//   - Zones are scope-based via a local variable; do not place a TRACY_ZONE
+//     macro on a line that also declares other variables.
+//   - With TRACY_ON_DEMAND (set by the CMake option of the same name) zones
+//     are only collected when a profiler connection is active, minimizing
+//     runtime overhead in production builds.
+
+#if defined(TRACY_ENABLE)
+#  include <tracy/Tracy.hpp>
+#  define TRACY_ZONE(name) ZoneScopedN(name)
+#  define TRACY_FRAME() FrameMark
+#  define TRACY_TEXT(str, len) ZoneText(str, len)
+#else
+#  define TRACY_ZONE(name) ((void)0)
+#  define TRACY_FRAME() ((void)0)
+#  define TRACY_TEXT(str, len) ((void)0)
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,34 +1,30 @@
-cmake_minimum_required(VERSION 3.10)
-project(visualization.matrix.tests)
+# Tests for visualization.matrix
+#
+# Included via add_subdirectory(tests) from the top-level CMakeLists.txt when
+# BUILD_TESTING=ON. GoogleTest is fetched on demand via FetchContent so the
+# tests do not depend on a system-provided GTest package.
 
-# Enable C++17
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-# Find GoogleTest
-find_package(GTest REQUIRED)
-find_package(GTestMain REQUIRED)
-
-# Include parent project for dependencies
-include_directories(
-    ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_SOURCE_DIR}/lib/kissfft
+# Fetch GoogleTest only when actually building tests (keeps regular builds lean).
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
 )
+# On Windows / MSVC prevent gtest from overriding the parent project's settings.
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
 
-# Add test executable
 add_executable(test_visualization_matrix
-    test_visualization_matrix.cpp
+  test_visualization_matrix.cpp
 )
 
-# Link GoogleTest and required libraries
-target_link_libraries(test_visualization_matrix
-    GTest::GTest
-    GTest::Main
-    m  # For math functions (log10f, sin, cos, etc.)
+target_link_libraries(test_visualization_matrix PRIVATE
+  GTest::gtest
+  GTest::gtest_main
+  m  # math: log10f, cos, sqrt, ...
 )
 
-# Enable testing
-enable_testing()
-
-# Add test to CTest
+# Register the test with CTest. Using the explicit add_test() form (rather than
+# gtest_discover_tests) keeps registration reliable without a build-time
+# discovery step, matching the original project layout.
 add_test(NAME test_visualization_matrix COMMAND test_visualization_matrix)


### PR DESCRIPTION
## Summary

Focused, additive build-system + CI changes addressing the parts of the requested plan that represent genuine gaps. Several items in the original plan were skipped because they rest on incorrect premises or already exist (details below).

### Changes made

- **CMake — activate tests (`Step 7`)**: The `BUILD_TESTING` block was a no-op (`# Add tests here when available`) even though `tests/CMakeLists.txt` existed. Now `add_subdirectory(tests)` is wired so `ctest` actually runs the existing GoogleTest suite.
- **CMake — code coverage (`Step 4`)**: `ENABLE_COVERAGE` now uses directory-scoped `add_compile_options(--coverage -O0 -g)` / `add_link_options(--coverage)`, ordered **before** the test subdirectory so the test target inherits coverage flags too. Guards against non-GCC/Clang toolchains.
- **CMake — clang-tidy / cppcheck (`Step 3`)**: Replaced the brittle target-property-only stub with proper `CMAKE_CXX_CLANG_TIDY` / `CMAKE_CXX_CPPCHECK` wiring that locates the tool and **gracefully skips** when absent (`ENABLE_CLANG_TIDY` / `ENABLE_CPPCHECK`).
- **CMake — Tracy profiler (`Step 5`)**: New `ENABLE_TRACY` / `TRACY_ON_DEMAND` options. When the tracy headers are present they are added to the include path and `TRACY_ENABLE`/`TRACY_ON_DEMAND` are defined; otherwise the option no-ops, so it is always safe to enable.
- **`tests/CMakeLists.txt`**: Converted from a standalone `project()` into a proper subdirectory. Fetches GoogleTest via `FetchContent` (no system GTest dependency) and registers the test with `add_test`.
- **`src/tracyprofiler.h`**: Dependency-free instrumentation shim. Pulls in Tracy zones when `TRACY_ENABLE` is defined and headers exist, else expands to no-ops — sources can be instrumented unconditionally without forcing a tracy dependency on regular builds.
- **`.github/workflows/code-coverage.yml`**: New gcov/lcov CI workflow: builds with `BUILD_TESTING=ON -DENABLE_COVERAGE=ON`, runs `ctest`, captures and filters lcov (excluding system/third-party/test-framework code), generates an HTML report, and uploads it as an artifact.

### Items intentionally NOT done (with reasons)

- **`Step 1 — OpenGL-Header anpassen (glad/glew → Kodi)`**: Premise is false. There is **no** `glad/glad.h` or `GL/glew.h` include anywhere in `src/`. The code already uses the correct Kodi headers (`<kodi/addon-instance/Visualization.h>`, `<kodi/gui/gl/Shader.h>` in `src/main.h:10-11`). Nothing to replace.
- **`Step 3` (clang-tidy/cppcheck) and `Step 5` (Tracy) CI**: The dedicated `.github/workflows/clang-tidy.yml`, `cppcheck.yml`, and `sonarqube.yml` **already exist** and run in CI. The CMake-side wiring (above) is the genuine gap; the CI workflows were not duplicated.
- **`Step 8 (Dockerfile)`**: Already exists as a working multi-stage build.
- **Steps 2, 6, 9, 10 and platform backends (Vulkan/Metal/DirectX)**: These are substantial architectural refactorings (multithreaded FFT, shader hot-reloading, dynamic resolution scaling, frame skipping, alternate graphics backends) of an 815-line `src/main.cpp` with no test coverage for the new behavior. Each is its own design decision and was not guessed at. Recommend tackling them as separate, scoped PRs.

## Verification

Local sandbox validation (no Kodi SDK available, so the addon module target cannot fully configure — that is expected and pre-existing):

- **Tests build & pass**: Standalone harness using the new `tests/CMakeLists.txt` pattern configured, built, and ran `test_visualization_matrix` — **14/14 tests PASSED**, discovered by `ctest`.
- **Coverage flags**: With `BUILD_TESTING=ON -DENABLE_COVERAGE=ON`, confirmed the test target inherits `--coverage -O0 -g` (compile) and `--coverage` (link); `.gcno`/`.gcda` artifacts generated after running tests.
- **New CMake blocks**: Stub-validated the top-level `CMakeLists.txt` configure with `-DENABLE_COVERAGE=ON`, `-DENABLE_TRACY=ON`, `-DENABLE_CLANG_TIDY=ON`, `-DENABLE_CPPCHECK=ON` — all configure cleanly, with graceful skip messages when the tool/headers are absent.
